### PR TITLE
HTTP.Request - Modified ResultMethod parameter to ReturnFormat

### DIFF
--- a/.github/workflows/Request_build_and_test_on_main.yml
+++ b/.github/workflows/Request_build_and_test_on_main.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_main.yml@main
     with:
-      workdir: Frends.HTTP.Request
+      workdir: Frends.HTTP.Request/
     secrets:
       badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}

--- a/.github/workflows/Request_build_and_test_on_push.yml
+++ b/.github/workflows/Request_build_and_test_on_push.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_test.yml@main
     with:
-      workdir: Frends.HTTP.Request
+      workdir: Frends.HTTP.Request/
     secrets:
       badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}
       test_feed_api_key: ${{ secrets.TASKS_TEST_FEED_API_KEY }}

--- a/Frends.HTTP.Request/CHANGELOG.md
+++ b/Frends.HTTP.Request/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.0] - 2023-05-08
+### Changed
+- [Breaking] Changed ResultMethod to ReturnFormat which describes the parameter better. 
+- Fixed documentation link in the main method.
+
 ## [1.0.0] - 2023-01-24
 ### Added
 - Initial implementation of Frends.HTTP.Request.

--- a/Frends.HTTP.Request/Frends.HTTP.Request.Tests/Helper.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request.Tests/Helper.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.DirectoryServices;
+using System.Runtime.InteropServices;
+
+namespace Frends.HTTP.Request.Tests;
+
+internal class Helper
+{
+    public static string CreateTestUser(string domain, string name, string pwd)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            throw new PlatformNotSupportedException("UseGivenCredentials feature is only supported on Windows.");
+
+        DirectoryEntry AD = new DirectoryEntry("WinNT://" + domain + ",computer");
+        DirectoryEntry NewUser = AD.Children.Add(name, "user");
+        NewUser.Invoke("SetPassword", new object[] { pwd });
+        NewUser.Invoke("Put", new object[] { "Description", "Test User from .NET" });
+        NewUser.CommitChanges();
+        DirectoryEntry grp;
+
+        grp = AD.Children.Find("Administrators", "group");
+        if (grp != null)
+            grp.Invoke("Add", new object[] { NewUser.Path.ToString() });
+        return $"{domain}//{name}";
+    }
+
+    public static void DeleteTestUser(string name)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            throw new PlatformNotSupportedException("UseGivenCredentials feature is only supported on Windows.");
+
+        DirectoryEntry localDirectory = new DirectoryEntry("WinNT://" + Environment.MachineName.ToString());
+        DirectoryEntries users = localDirectory.Children;
+        DirectoryEntry user = users.Find(name);
+        users.Remove(user);
+    }
+}
+

--- a/Frends.HTTP.Request/Frends.HTTP.Request.Tests/MockHttpClientFactory.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request.Tests/MockHttpClientFactory.cs
@@ -1,0 +1,19 @@
+﻿using System.Net.Http;
+using Frends.HTTP.Request.Definitions;
+using RichardSzalay.MockHttp;
+
+namespace Frends.HTTP.Request.Tests;
+
+public class MockHttpClientFactory : IHttpClientFactory
+{
+    private readonly MockHttpMessageHandler _mockHttpMessageHandler;
+
+    public MockHttpClientFactory(MockHttpMessageHandler mockHttpMessageHandler)
+    {
+        _mockHttpMessageHandler = mockHttpMessageHandler;
+    }
+    public HttpClient CreateClient(Options options)
+    {
+        return _mockHttpMessageHandler.ToHttpClient();
+    }
+}

--- a/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
@@ -223,7 +223,7 @@ public class UnitTests
             Url = "http://localhost:9191/endpoint",
             Headers = new Header[0],
             Message = "",
-            ResultMethod = ResultMethod.REST
+            ResultMethod = ReturnFormat.JToken
         };
         var options = new Options
         {
@@ -252,7 +252,7 @@ public class UnitTests
 
 
         var input = new Input
-        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ResultMethod.REST };
+        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ReturnFormat.JToken };
         var options = new Options
         { ConnectionTimeoutSeconds = 60, Authentication = Authentication.OAuth, Token = "fooToken" };
 
@@ -268,7 +268,7 @@ public class UnitTests
     public async Task RestRequestShouldNotThrowIfReturnIsEmpty()
     {
         var input = new Input
-        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ResultMethod.REST };
+        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ReturnFormat.JToken };
         var options = new Options
         { ConnectionTimeoutSeconds = 60, Authentication = Authentication.OAuth, Token = "fooToken" };
 
@@ -284,7 +284,7 @@ public class UnitTests
     public void RestRequestShouldThrowIfReturnIsNotValidJson()
     {
         var input = new Input
-        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ResultMethod.REST };
+        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ReturnFormat.JToken };
         var options = new Options
         { ConnectionTimeoutSeconds = 60, Authentication = Authentication.OAuth, Token = "fooToken" };
 
@@ -302,7 +302,7 @@ public class UnitTests
         const string expectedReturn = "<foo>BAR</foo>";
 
         var input = new Input
-        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ResultMethod.HTTP };
+        { Method = Method.Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "", ResultMethod = ReturnFormat.String };
         var options = new Options { ConnectionTimeoutSeconds = 60 };
 
         _mockHttpMessageHandler.When(input.Url)
@@ -323,7 +323,7 @@ public class UnitTests
             Url = "http://localhost:9191/endpoint",
             Headers = new Header[] { },
             Message = message,
-            ResultMethod = ResultMethod.HTTP
+            ResultMethod = ReturnFormat.String
         };
         var options = new Options { ConnectionTimeoutSeconds = 60 };
 
@@ -350,7 +350,7 @@ public class UnitTests
             Url = "http://localhost:9191/endpoint",
             Headers = new Header[1] { contentType },
             Message = requestMessage,
-            ResultMethod = ResultMethod.HTTP
+            ResultMethod = ReturnFormat.String
         };
         var options = new Options { ConnectionTimeoutSeconds = 60 };
 

--- a/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
@@ -185,7 +185,7 @@ public class UnitTests
         _mockHttpMessageHandler.VerifyNoOutstandingExpectation();
         Assert.IsTrue(result.Body.Contains("FooBar"));
     }
-    
+
     [TestMethod]
     public async Task AuthorizationHeaderShouldOverrideOption()
     {
@@ -263,7 +263,7 @@ public class UnitTests
         var resultBody = result.Body as JToken;
         Assert.AreEqual(new JValue("Bar"), resultBody["Foo"]);
     }
-    
+
     [TestMethod]
     public async Task RestRequestShouldNotThrowIfReturnIsEmpty()
     {
@@ -279,7 +279,7 @@ public class UnitTests
 
         Assert.AreEqual(new JValue(""), result.Body);
     }
-    
+
     [TestMethod]
     public void RestRequestShouldThrowIfReturnIsNotValidJson()
     {
@@ -295,7 +295,7 @@ public class UnitTests
 
         Assert.AreEqual("Unable to read response message as json: <fail>failbar<fail>", ex.Message);
     }
-    
+
     [TestMethod]
     public async Task HttpRequestBodyReturnShouldBeOfTypeString()
     {
@@ -311,7 +311,7 @@ public class UnitTests
 
         Assert.AreEqual(expectedReturn, result.Body);
     }
-    
+
     [TestMethod]
     public async Task PatchShouldComeThrough()
     {
@@ -335,7 +335,7 @@ public class UnitTests
         _mockHttpMessageHandler.VerifyNoOutstandingExpectation();
         Assert.IsTrue(result.Body.Contains("foo åäö"));
     }
-    
+
     [TestMethod]
     public async Task RequestShouldSetEncodingWithContentTypeCharsetIgnoringCase()
     {
@@ -361,20 +361,5 @@ public class UnitTests
 
         _mockHttpMessageHandler.VerifyNoOutstandingExpectation();
         Assert.IsTrue(result.Body.Contains("foo åäö"));
-    }
-}
-
-public class MockHttpClientFactory : IHttpClientFactory
-{
-    private readonly MockHttpMessageHandler _mockHttpMessageHandler;
-
-    public MockHttpClientFactory(MockHttpMessageHandler mockHttpMessageHandler)
-    {
-        _mockHttpMessageHandler = mockHttpMessageHandler;
-    }
-    public HttpClient CreateClient(Options options)
-    {
-        return _mockHttpMessageHandler.ToHttpClient();
-
     }
 }

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Input.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Input.cs
@@ -19,8 +19,8 @@ public class Input
     /// The HTTP result method to be used with the request.
     /// </summary>
     /// <example>REST</example>
-    [DefaultValue(ResultMethod.HTTP)]
-    public ResultMethod ResultMethod { get; set; }
+    [DefaultValue(ReturnFormat.String)]
+    public ReturnFormat ResultMethod { get; set; }
 
     /// <summary>
     /// The URL with protocol and path. You can include query parameters directly in the url.

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Options.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Options.cs
@@ -111,7 +111,7 @@ public class Options
     public bool AllowInvalidResponseContentTypeCharSet { get; set; }
 
     /// <summary>
-    /// Throw exception if return code of request is not successfull
+    /// Throw exception if return code of request is not successfull.
     /// </summary>
     /// <example>true</example>
     public bool ThrowExceptionOnErrorResponse { get; set; }

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/ResultMethod.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/ResultMethod.cs
@@ -4,14 +4,14 @@
 /// Type of HTTP Request result
 /// </summary>
 /// <example>GET</example>
-public enum ResultMethod
+public enum ReturnFormat
 {
     /// <summary>
     /// HTTP result as a string.
     /// </summary>
-    HTTP,
+    String,
     /// <summary>
-    /// REST result as an object.
+    /// REST result as an JToken.
     /// </summary>
-    REST
+    JToken
 }

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Extensions.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Extensions.cs
@@ -6,9 +6,11 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Frends.HTTP.Request.Definitions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Frends.HTTP.Request;
 
+[ExcludeFromCodeCoverage]
 internal static class Extensions
 {
     internal static void SetHandlerSettingsBasedOnOptions(this HttpClientHandler handler, Options options)

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
@@ -25,6 +25,7 @@
 	<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
+	<PackageReference Include="System.DirectoryServices" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
@@ -38,7 +38,7 @@ public class HTTP
 
     /// <summary>
     /// Execute a HTTP or REST request.
-    /// [Documentation](https://tasks.frends.com/tasks#frends-tasks/Frends.HTTP.Request)
+    /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.HTTP.Request)
     /// </summary>
     /// <param name="input"></param>
     /// <param name="options"></param>
@@ -70,13 +70,13 @@ public class HTTP
                 dynamic response;
 
                 switch (input.ResultMethod) {
-                    case ResultMethod.HTTP:
+                    case ReturnFormat.String:
                         var hbody = responseMessage.Content != null ? await responseMessage.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false) : null;
                         var hstatusCode = (int)responseMessage.StatusCode;
                         var hheaders = GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content?.Headers);
                         response = new Result(hbody, hheaders, hstatusCode);
                         break;
-                    case ResultMethod.REST:
+                    case ReturnFormat.JToken:
                         var rbody = TryParseRequestStringResultAsJToken(await responseMessage.Content.ReadAsStringAsync()
                         .ConfigureAwait(false));
                         var rstatusCode = (int)responseMessage.StatusCode;

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
@@ -51,8 +51,7 @@ public class HTTP
         CancellationToken cancellationToken
     )
     {
-        if(string.IsNullOrEmpty(input.Url))
-            throw new ArgumentNullException("Url can not be empty.");
+        if (string.IsNullOrEmpty(input.Url)) throw new ArgumentNullException("Url can not be empty.");
 
         var httpClient = GetHttpClientForOptions(options);
         var headers = GetHeaderDictionary(input.Headers, options);

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Runtime.Caching;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 
 [assembly: InternalsVisibleTo("Frends.HTTP.Request.Tests")]
 namespace Frends.HTTP.Request;
@@ -50,51 +51,50 @@ public class HTTP
         CancellationToken cancellationToken
     )
     {
-        if(string.IsNullOrEmpty(input.Url)) throw new ArgumentNullException("Url can not be empty.");
+        if(string.IsNullOrEmpty(input.Url))
+            throw new ArgumentNullException("Url can not be empty.");
 
         var httpClient = GetHttpClientForOptions(options);
         var headers = GetHeaderDictionary(input.Headers, options);
 
-        using (var content = GetContent(input, headers))
+        using var content = GetContent(input, headers);
+        using var responseMessage = await GetHttpRequestResponseAsync(
+                httpClient,
+                input.Method.ToString(),
+                input.Url,
+                content,
+                headers,
+                options,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        dynamic response;
+
+        switch (input.ResultMethod)
         {
-            using (var responseMessage = await GetHttpRequestResponseAsync(
-                    httpClient,
-                    input.Method.ToString(),
-                    input.Url,
-                    content,
-                    headers,
-                    options,
-                    cancellationToken)
-                .ConfigureAwait(false))
-            {
-                dynamic response;
-
-                switch (input.ResultMethod) {
-                    case ReturnFormat.String:
-                        var hbody = responseMessage.Content != null ? await responseMessage.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false) : null;
-                        var hstatusCode = (int)responseMessage.StatusCode;
-                        var hheaders = GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content?.Headers);
-                        response = new Result(hbody, hheaders, hstatusCode);
-                        break;
-                    case ReturnFormat.JToken:
-                        var rbody = TryParseRequestStringResultAsJToken(await responseMessage.Content.ReadAsStringAsync()
-                        .ConfigureAwait(false));
-                        var rstatusCode = (int)responseMessage.StatusCode;
-                        var rheaders = GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content.Headers);
-                        response = new Result(rbody, rheaders, rstatusCode);
-                        break;
-                    default: throw new InvalidOperationException();
-                }
-
-                if (!responseMessage.IsSuccessStatusCode && options.ThrowExceptionOnErrorResponse)
-                {
-                    throw new WebException(
-                        $"Request to '{input.Url}' failed with status code {(int)responseMessage.StatusCode}. Response body: {response.Body}");
-                }
-
-                return response;
-            }
+            case ReturnFormat.String:
+                var hbody = responseMessage.Content != null ? await responseMessage.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false) : null;
+                var hstatusCode = (int)responseMessage.StatusCode;
+                var hheaders = GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content?.Headers);
+                response = new Result(hbody, hheaders, hstatusCode);
+                break;
+            case ReturnFormat.JToken:
+                var rbody = TryParseRequestStringResultAsJToken(await responseMessage.Content.ReadAsStringAsync()
+                .ConfigureAwait(false));
+                var rstatusCode = (int)responseMessage.StatusCode;
+                var rheaders = GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content.Headers);
+                response = new Result(rbody, rheaders, rstatusCode);
+                break;
+            default: throw new InvalidOperationException();
         }
+
+        if (!responseMessage.IsSuccessStatusCode && options.ThrowExceptionOnErrorResponse)
+        {
+            throw new WebException(
+                $"Request to '{input.Url}' failed with status code {(int)responseMessage.StatusCode}. Response body: {response.Body}");
+        }
+
+        return response;
     }
 
     // Combine response- and responsecontent header to one dictionary
@@ -173,6 +173,7 @@ public class HTTP
         return httpClient;
     }
 
+    [ExcludeFromCodeCoverage]
     private static string GetHttpClientCacheKey(Options options)
     {
         // Includes everything except for options.Token, which is used on request level, not http client level

--- a/Frends.HTTP.Request/README.md
+++ b/Frends.HTTP.Request/README.md
@@ -10,8 +10,7 @@ Returns the object of body, headers and statuscode.
 
 ## Installing
 
-You can install the Task via Frends UI Task View or you can find the NuGet package from the following NuGet feed
-https://www.myget.org/F/frends-tasks/api/v2.
+You can install the Task via Frends UI Task View.
 
 ## Building
 


### PR DESCRIPTION
#12 
- [Breaking] Changed ResultMethod to ReturnFormat which describes the parameter better. 
- Fixed documentation link in the main method.