### PR TITLE
Frends.HTTP.Request - Fixed main and test workflows

### DIFF
--- a/.github/workflows/Request_build_and_test_on_main.yml
+++ b/.github/workflows/Request_build_and_test_on_main.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_main.yml@main
     with:
-      workdir: Frends.HTTP.Request/
+      workdir: Frends.HTTP.Request
     secrets:
       badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}

--- a/.github/workflows/Request_build_and_test_on_push.yml
+++ b/.github/workflows/Request_build_and_test_on_push.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     uses: FrendsPlatform/FrendsTasks/.github/workflows/linux_build_test.yml@main
     with:
-      workdir: Frends.HTTP.Request/
+      workdir: Frends.HTTP.Request
     secrets:
       badge_service_api_key: ${{ secrets.BADGE_SERVICE_API_KEY }}
       test_feed_api_key: ${{ secrets.TASKS_TEST_FEED_API_KEY }}


### PR DESCRIPTION
Removed forward slash from workdir in workflows because the original issue will be fixed in base workflows.