### PR TITLE
HTTP.Request - Added cancellationToken to ReadAsStringAsync method

### DIFF
--- a/Frends.HTTP.Request/CHANGELOG.md
+++ b/Frends.HTTP.Request/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.1] - 2023-06-09
+### Fixed
+- Fixed issue with terminating the Task by adding cancellationToken to the method ReadAsStringAsync when JToken as ReturnFormat. 
+
 ## [1.1.0] - 2023-05-08
 ### Changed
 - [Breaking] Changed ResultMethod to ReturnFormat which describes the parameter better. 

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
@@ -78,7 +78,7 @@ public class HTTP
                 response = new Result(hbody, hheaders, hstatusCode);
                 break;
             case ReturnFormat.JToken:
-                var rbody = TryParseRequestStringResultAsJToken(await responseMessage.Content.ReadAsStringAsync()
+                var rbody = TryParseRequestStringResultAsJToken(await responseMessage.Content.ReadAsStringAsync(cancellationToken)
                 .ConfigureAwait(false));
                 var rstatusCode = (int)responseMessage.StatusCode;
                 var rheaders = GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content.Headers);


### PR DESCRIPTION
#22 
- Fixed issue with terminating the Task by adding cancellationToken to the method ReadAsStringAsync when JToken as ReturnFormat.