### PR TITLE
clarify Certificate Source descriptions

### DIFF
--- a/Frends.HTTP.DownloadFile/CHANGELOG.md
+++ b/Frends.HTTP.DownloadFile/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.1] - 2024-12-30
+## [1.1.0] - 2024-12-30
 ### Changed
 - Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
 

--- a/Frends.HTTP.DownloadFile/CHANGELOG.md
+++ b/Frends.HTTP.DownloadFile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1] - 2024-12-30
+### Changed
+- Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
+
 ## [1.0.0] - 2023-01-27
 ### Added
 - Initial implementation.

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
@@ -57,7 +57,7 @@ public class Options
 
     /// <summary>
     /// Applicable only when Certificate Source is "String".
-    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
@@ -47,7 +47,8 @@ public class Options
     public CertificateSource ClientCertificateSource { get; set; }
 
     /// <summary>
-    /// Path to the Client Certificate when using a file as the Certificate Source, pfx (pkcs12) files are recommended. For other supported formats, see
+    /// Applicable only when Certificate Source is "File".
+    /// Path to the Client Certificate, pfx (pkcs12) files are recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -55,7 +56,8 @@ public class Options
     public string ClientCertificateFilePath { get; set; }
 
     /// <summary>
-    /// Client certificate bytes as a base64 encoded string when using a string as the Certificate Source , pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Applicable only when Certificate Source is "String".
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -63,7 +65,8 @@ public class Options
     public string ClientCertificateInBase64 { get; set; }
 
     /// <summary>
-    /// Key phrase (password) to access the certificate data when using a string or file as the Certificate Source
+    /// Applicable only when Certificate Source is "File" or "String".
+    /// Key phrase (password) to access the certificate data
     /// </summary>
     /// <example>string value</example>
     [PasswordPropertyText]
@@ -71,6 +74,7 @@ public class Options
     public string ClientCertificateKeyPhrase { get; set; }
 
     /// <summary>
+    /// Applicable only when Certificate Source is "CertificateStore".
     /// Thumbprint for using client certificate authentication.
     /// </summary>
     /// <example>thumbprint</example>

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.csproj
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.csproj
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.Request/CHANGELOG.md
+++ b/Frends.HTTP.Request/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.1] - 2024-12-30
+### Changed
+- Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
+
 ## [1.2.0] - 2024-08-19
 ### Changed
 - Removed handling where only PATCH, PUT, POST and DELETE requests were allowed to have the Content-Type header and content, due to HttpClient failing if e.g., a GET request had content. HttpClient has since been updated to tolerate such requests.

--- a/Frends.HTTP.Request/CHANGELOG.md
+++ b/Frends.HTTP.Request/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.1] - 2024-12-30
+## [1.3.0] - 2024-12-30
 ### Changed
 - Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
 

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Options.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Options.cs
@@ -56,7 +56,7 @@ public class Options
 
     /// <summary>
     /// Applicable only when Certificate Source is "String".
-    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Options.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Definitions/Options.cs
@@ -46,7 +46,8 @@ public class Options
     public CertificateSource ClientCertificateSource { get; set; }
 
     /// <summary>
-    /// Path to the Client Certificate when using a file as the Certificate Source, pfx (pkcs12) files are recommended. For other supported formats, see
+    /// Applicable only when Certificate Source is "File".
+    /// Path to the Client Certificate, pfx (pkcs12) files are recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -54,7 +55,8 @@ public class Options
     public string ClientCertificateFilePath { get; set; }
 
     /// <summary>
-    /// Client certificate bytes as a base64 encoded string when using a string as the Certificate Source , pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Applicable only when Certificate Source is "String".
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -62,7 +64,8 @@ public class Options
     public string ClientCertificateInBase64 { get; set; }
 
     /// <summary>
-    /// Key phrase (password) to access the certificate data when using a string or file as the Certificate Source
+    /// Applicable only when Certificate Source is "File" or "String".
+    /// Key phrase (password) to access the certificate data
     /// </summary>
     /// <example>string value</example>
     [PasswordPropertyText]
@@ -70,6 +73,7 @@ public class Options
     public string ClientCertificateKeyPhrase { get; set; }
 
     /// <summary>
+    /// Applicable only when Certificate Source is "CertificateStore".
     /// Thumbprint for using client certificate authentication.
     /// </summary>
     /// <example>thumbprint</example>

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.2.1</Version>
+    <Version>1.3.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.RequestBytes/CHANGELOG.md
+++ b/Frends.HTTP.RequestBytes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.2] - 2024-12-30
+### Changed
+- Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
+
 ## [1.0.1] - 2024-01-17
 ### Fixed
 - Fixed issues which CodeQL found in the codebase.

--- a/Frends.HTTP.RequestBytes/CHANGELOG.md
+++ b/Frends.HTTP.RequestBytes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.2] - 2024-12-30
+## [1.1.0] - 2024-12-30
 ### Changed
 - Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
 

--- a/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Definitions/Options.cs
+++ b/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Definitions/Options.cs
@@ -56,7 +56,7 @@ public class Options
 
     /// <summary>
     /// Applicable only when Certificate Source is "String".
-    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>

--- a/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Definitions/Options.cs
+++ b/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Definitions/Options.cs
@@ -46,7 +46,8 @@ public class Options
     public CertificateSource ClientCertificateSource { get; set; }
 
     /// <summary>
-    /// Path to the Client Certificate when using a file as the Certificate Source, pfx (pkcs12) files are recommended. For other supported formats, see
+    /// Applicable only when Certificate Source is "File".
+    /// Path to the Client Certificate, pfx (pkcs12) files are recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -54,7 +55,8 @@ public class Options
     public string ClientCertificateFilePath { get; set; }
 
     /// <summary>
-    /// Client certificate bytes as a base64 encoded string when using a string as the Certificate Source , pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Applicable only when Certificate Source is "String".
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -62,7 +64,8 @@ public class Options
     public string ClientCertificateInBase64 { get; set; }
 
     /// <summary>
-    /// Key phrase (password) to access the certificate data when using a string or file as the Certificate Source
+    /// Applicable only when Certificate Source is "File" or "String".
+    /// Key phrase (password) to access the certificate data
     /// </summary>
     /// <example>string value</example>
     [PasswordPropertyText]
@@ -70,6 +73,7 @@ public class Options
     public string ClientCertificateKeyPhrase { get; set; }
 
     /// <summary>
+    /// Applicable only when Certificate Source is "CertificateStore".
     /// Thumbprint for using client certificate authentication.
     /// </summary>
     /// <example>thumbprint</example>

--- a/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes.csproj
+++ b/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes.csproj
+++ b/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.SendAndReceiveBytes/CHANGELOG.md
+++ b/Frends.HTTP.SendAndReceiveBytes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1] - 2024-12-30
+### Changed
+- Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
+
 ## [1.0.0] - 2023-06-01
 ### Added
 - Initial implementation.

--- a/Frends.HTTP.SendAndReceiveBytes/CHANGELOG.md
+++ b/Frends.HTTP.SendAndReceiveBytes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.1] - 2024-12-30
+## [1.1.0] - 2024-12-30
 ### Changed
 - Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
 

--- a/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Definitions/Options.cs
+++ b/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Definitions/Options.cs
@@ -58,7 +58,7 @@ public class Options
 
     /// <summary>
     /// Applicable only when Certificate Source is "String".
-    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>

--- a/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Definitions/Options.cs
+++ b/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Definitions/Options.cs
@@ -48,7 +48,8 @@ public class Options
     public CertificateSource ClientCertificateSource { get; set; }
 
     /// <summary>
-    /// Path to the Client Certificate when using a file as the Certificate Source, pfx (pkcs12) files are recommended. For other supported formats, see
+    /// Applicable only when Certificate Source is "File".
+    /// Path to the Client Certificate, pfx (pkcs12) files are recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -56,7 +57,8 @@ public class Options
     public string ClientCertificateFilePath { get; set; }
 
     /// <summary>
-    /// Client certificate bytes as a base64 encoded string when using a string as the Certificate Source , pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Applicable only when Certificate Source is "String".
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -64,7 +66,8 @@ public class Options
     public string ClientCertificateInBase64 { get; set; }
 
     /// <summary>
-    /// Key phrase (password) to access the certificate data when using a string or file as the Certificate Source
+    /// Applicable only when Certificate Source is "File" or "String".
+    /// Key phrase (password) to access the certificate data
     /// </summary>
     /// <example>string value</example>
     [DisplayFormat(DataFormatString = "Text")]
@@ -73,6 +76,7 @@ public class Options
     public string ClientCertificateKeyPhrase { get; set; }
 
     /// <summary>
+    /// Applicable only when Certificate Source is "CertificateStore".
     /// Thumbprint for using client certificate authentication.
     /// </summary>
     /// <example>thumbprint</example>

--- a/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes.csproj
+++ b/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes.csproj
+++ b/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes/Frends.HTTP.SendAndReceiveBytes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.SendBytes/CHANGELOG.md
+++ b/Frends.HTTP.SendBytes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.1] - 2024-12-30
+## [1.1.0] - 2024-12-30
 ### Changed
 - Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
 

--- a/Frends.HTTP.SendBytes/CHANGELOG.md
+++ b/Frends.HTTP.SendBytes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1] - 2024-12-30
+### Changed
+- Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.
+
 ## [1.0.0] - 2023-05-30
 ### Added
 - Initial implementation.

--- a/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Definitions/Options.cs
+++ b/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Definitions/Options.cs
@@ -56,7 +56,7 @@ public class Options
 
     /// <summary>
     /// Applicable only when Certificate Source is "String".
-    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>

--- a/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Definitions/Options.cs
+++ b/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Definitions/Options.cs
@@ -46,7 +46,8 @@ public class Options
     public CertificateSource ClientCertificateSource { get; set; }
 
     /// <summary>
-    /// Path to the Client Certificate when using a file as the Certificate Source, pfx (pkcs12) files are recommended. For other supported formats, see
+    /// Applicable only when Certificate Source is "File".
+    /// Path to the Client Certificate, pfx (pkcs12) files are recommended. For other supported formats, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -54,7 +55,8 @@ public class Options
     public string ClientCertificateFilePath { get; set; }
 
     /// <summary>
-    /// Client certificate bytes as a base64 encoded string when using a string as the Certificate Source , pfx (pkcs12) format is recommended. For other supported formates, see
+    /// Applicable only when Certificate Source is "String".
+    /// Client certificate bytes as a base64 encoded string, pfx (pkcs12) format is recommended. For other supported formates, see
     /// https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.import?view=netframework-4.7.1
     /// </summary>
     /// <example>domain\path</example>
@@ -62,7 +64,8 @@ public class Options
     public string ClientCertificateInBase64 { get; set; }
 
     /// <summary>
-    /// Key phrase (password) to access the certificate data when using a string or file as the Certificate Source
+    /// Applicable only when Certificate Source is "File" or "String".
+    /// Key phrase (password) to access the certificate data
     /// </summary>
     /// <example>string value</example>
     [PasswordPropertyText]
@@ -70,6 +73,7 @@ public class Options
     public string ClientCertificateKeyPhrase { get; set; }
 
     /// <summary>
+    /// Applicable only when Certificate Source is "CertificateStore".
     /// Thumbprint for using client certificate authentication.
     /// </summary>
     /// <example>thumbprint</example>

--- a/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes.csproj
+++ b/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes.csproj
+++ b/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
In current Frends implementation it's not possible to set options visibility based on two conditions (Authentication.ClientCertificate AND CertificateSource is one of types). It was decided to not make a breaking changes and just update descriptions to make it clear which options should be used in which scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Clarified descriptions of ClientCertificate suboptions across multiple HTTP-related packages.
	- Added clearer information about certificate usage for different certificate sources.

- **New Features**
	- Introduced `CertificateThumbprint` property for certificate store authentication in several HTTP packages.

- **Version Updates**
	- Updated versions for Frends.HTTP packages:
		- DownloadFile: 1.0.0 → 1.1.0
		- Request: 1.2.0 → 1.3.0
		- RequestBytes: 1.0.1 → 1.1.0
		- SendAndReceiveBytes: 1.0.0 → 1.1.0
		- SendBytes: 1.0.0 → 1.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->