### PR TITLE
Set ContentBytes parameter display format to Expression

### DIFF
--- a/Frends.HTTP.SendBytes/CHANGELOG.md
+++ b/Frends.HTTP.SendBytes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0] - 2025-04-10
+### Changed
+- Updated the default display format for the `ContentBytes` option to `Expression`.
+
 ## [1.1.0] - 2024-12-30
 ### Changed
 - Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.

--- a/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Definitions/Input.cs
+++ b/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Definitions/Input.cs
@@ -27,6 +27,7 @@ public class Input
     /// The content to send as byte array
     /// </summary>
     /// <example>{ "Body": "Message" }</example>
+    [DisplayFormat(DataFormatString = "Expression")]
     public byte[] ContentBytes { get; set; }
 
     /// <summary>

--- a/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes.csproj
+++ b/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes/Frends.HTTP.SendBytes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
Reopened to fix branch name to correct ticket number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the configuration experience by updating the default display format for binary data. Users now see a clearer, expression-based view that streamlines the setup process while retaining existing functionality.

- **Chores**
  - Updated the module version to 1.2.0, reflecting the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->