### PR TITLE
Added overwrite parameter

### DIFF
--- a/Frends.HTTP.DownloadFile/CHANGELOG.md
+++ b/Frends.HTTP.DownloadFile/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0] - 2025-05-15
+### Changed
+- Added new Overwrite parameter to control whether the downloaded file should replace an existing one.
+- Use the default parameter value ('false') if you want the task to work as before.
+
 ## [1.1.0] - 2024-12-30
 ### Changed
 - Descriptions of ClientCertificate suboptions includes clearer information about usage in terms of different types of ClientCertificate.

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.Tests/UnitTests.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.Tests/UnitTests.cs
@@ -284,4 +284,46 @@ public class UnitTests
             throw new Exception(ex.Message);
         }
     }
+
+    [TestMethod]
+    public async Task TestFileDownload_WithOverwriteTrue_ShouldOverwriteExistingFile()
+    {
+        var input = new Input
+        {
+            Url = _targetFileAddress,
+            FilePath = _filePath,
+            Headers = null
+        };
+
+        var options = new Options
+        {
+            AllowInvalidCertificate = true,
+            AllowInvalidResponseContentTypeCharSet = true,
+            Authentication = Authentication.None,
+            AutomaticCookieHandling = true,
+            CertificateThumbprint = "",
+            ClientCertificateFilePath = "",
+            ClientCertificateInBase64 = "",
+            ClientCertificateKeyPhrase = "",
+            ClientCertificateSource = CertificateSource.File,
+            ConnectionTimeoutSeconds = 60,
+            FollowRedirects = true,
+            LoadEntireChainForCertificate = true,
+            Password = "",
+            ThrowExceptionOnErrorResponse = true,
+            Token = "",
+            Username = "domain\\username",
+            Overwrite = true
+        };
+
+        var result = await HTTP.DownloadFile(input, options, default);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.FilePath);
+        Assert.IsTrue(File.Exists(result.FilePath));
+
+        var actualContent = File.ReadAllText(_filePath);
+        Assert.AreNotEqual("OLD CONTENT", actualContent, "File should have been overwritten.");
+    }
 }

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.Tests/UnitTests.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.Tests/UnitTests.cs
@@ -288,6 +288,8 @@ public class UnitTests
     [TestMethod]
     public async Task TestFileDownload_WithOverwriteTrue_ShouldOverwriteExistingFile()
     {
+        File.WriteAllText(_filePath, "OLD CONTENT");
+
         var input = new Input
         {
             Url = _targetFileAddress,

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
@@ -127,4 +127,11 @@ public class Options
     /// <example>true</example>
     [DefaultValue(true)]
     public bool AutomaticCookieHandling { get; set; } = true;
+
+    /// <summary>
+    /// If set to true, an existing file at the target path will be overwritten during download.
+    /// <example>false</example>
+    [DefaultValue(false)]
+    public bool Overwrite { get; set; } = false;
+
 }

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
@@ -129,7 +129,7 @@ public class Options
     public bool AutomaticCookieHandling { get; set; } = true;
 
     /// <summary>
-    /// If set to true, an existing file at the target path will be overwritten during download.
+    /// If set to true, an existing file at the target path will be overwritten during download
     /// <example>false</example>
     [DefaultValue(false)]
     public bool Overwrite { get; set; } = false;

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Definitions/Options.cs
@@ -129,7 +129,8 @@ public class Options
     public bool AutomaticCookieHandling { get; set; } = true;
 
     /// <summary>
-    /// If set to true, an existing file at the target path will be overwritten during download
+    /// If set to true, an existing file at the target path will be overwritten during download.
+    /// </summary>
     /// <example>false</example>
     [DefaultValue(false)]
     public bool Overwrite { get; set; } = false;

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/DownloadFile.cs
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/DownloadFile.cs
@@ -72,8 +72,10 @@ public static class HTTP
                 }
             }
 
+            var fileMode = options.Overwrite ? FileMode.Create : FileMode.CreateNew;
+
             using var s = await httpClient.GetStreamAsync(input.Url, cancellationToken);
-            using var fs = new FileStream(input.FilePath, FileMode.CreateNew);
+            using var fs = new FileStream(input.FilePath, fileMode);
             await s.CopyToAsync(fs, cancellationToken);
 
             return new Result(true, fs.Name);

--- a/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.csproj
+++ b/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile/Frends.HTTP.DownloadFile.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an "Overwrite" option for file downloads, allowing users to choose whether an existing file should be replaced. The default setting preserves existing files.
- **Tests**
	- Added a test to ensure files are correctly overwritten when the overwrite option is used.
- **Documentation**
	- Updated changelog to reflect the new version and feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->