### PR TITLE
Changed the return type of RequestBytes from Task<object> to Task<Res…

### DIFF
--- a/Frends.HTTP.RequestBytes/CHANGELOG.md
+++ b/Frends.HTTP.RequestBytes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2025-03-25
+### Changed
+- Changed the return type of RequestBytes from Task<object> to Task<Result>
+
 ## [1.2.0] - 2025-03-25
 ### Changed
 - Update packages:

--- a/Frends.HTTP.RequestBytes/CHANGELOG.md
+++ b/Frends.HTTP.RequestBytes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.3.0] - 2025-03-25
+## [1.3.0] - 2025-10-10
 ### Changed
 - Changed the return type of RequestBytes from Task<object> to Task<Result>
 

--- a/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes.csproj
+++ b/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0</TargetFrameworks>
-		<Version>1.2.0</Version>
+		<Version>1.3.0</Version>
 		<Authors>Frends</Authors>
 		<Copyright>Frends</Copyright>
 		<Company>Frends</Company>

--- a/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/RequestBytes.cs
+++ b/Frends.HTTP.RequestBytes/Frends.HTTP.RequestBytes/RequestBytes.cs
@@ -42,7 +42,7 @@ public class HTTP
     /// <param name="options"></param>
     /// <param name="cancellationToken"/>
     /// <returns>Object { dynamic Body, double BodySizeInMegaBytes, MediaTypeHeaderValue ContentType, Dictionary(string, string) Headers, int StatusCode }</returns>
-    public static async Task<object> RequestBytes([PropertyTab] Input input, [PropertyTab] Options options, CancellationToken cancellationToken)
+    public static async Task<Result> RequestBytes([PropertyTab] Input input, [PropertyTab] Options options, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(input.Url)) throw new ArgumentNullException("Url can not be empty.");
 


### PR DESCRIPTION
…ult>

[]# Frends Task Pull Request

## Summary
<!-- Brief description of changes -->

## Review Checklist

### 1. Frends Task Project Files
- Path: `Frends.*/Frends.*/*.csproj`
- [ ] Targets .NET 8
- [ ] Uses MIT license (`<PackageLicenseExpression>MIT</PackageLicenseExpression>`)
- [ ] Contains required fields:
  - [ ] `<Version>`
  - [ ] `<Authors>Frends</Authors>`
  - [ ] `<Description>`
  - [ ] `<RepositoryUrl>`
  - [ ] `<GenerateDocumentationFile>true</GenerateDocumentationFile>`

### 2. File: FrendsTaskMetadata.json
- [ ] Present: `Frends.*/Frends.*/FrendsTaskMetadata.json`
- [ ] FrendsTaskMetadata.json contains correct task method reference
- [ ] FrendsTaskMetadata.json is included in the project nuget package with path = "/"

### 3. File: README.md
- [ ] Present: `Frends.*/README.md`
- [ ] Contains badges (build, license, coverage)
- [ ] Includes developer setup instructions
- [ ] Does not include parameter descriptions

### 4. File: CHANGELOG.md
- [ ] Present: `Frends.*/CHANGELOG.md`
- [ ] Includes all functional changes
- [ ] Indicates breaking changes with upgrade notes
- [ ] Avoids non-functional notes like "refactored xyz"
- [ ] CHANGELOG.md is included in the project nuget package with path = "/"

### 5. File: migration.json
- [ ] Present: `Frends.*/Frends.*/migration.json`
- [ ] Contains breaking change migration information for Frends, if breaking changes exist
- [ ] migration.json is included in the project nuget package with path = "/"

### 6. Source Code Documentation
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Every public method and class has:
  - [ ] `<summary>` XML comments
  - [ ] `<example>` XML comments
  - [ ] Optionally `<frendsdocs>` XML comments, if needed
- [ ] Follows Microsoft C# code conventions
- [ ] Uses semantic task result documentation (Success, Error, Data)

### 7. GitHub Actions Workflows
- Path: `.github/workflows/*.yml`
- [ ] Task has required workflow files:
  - [ ] `*_test.yml`
  - [ ] `*_main.yml`
  - [ ] `*_release.yml`
- [ ] Correct workdir pointing to task folder
- [ ] Docker setup included if task depends on external system (docker-compose.yml)

### 8. Task Result Object Structure
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Category attribute is present, if applicable
- [ ] All task result classes include:
  - [ ] `Success` (bool)
  - [ ] Task-specific return value (e.g., Data, FilePaths), if needed
  - [ ] Error object with Message and AdditionalInfo
- [ ] Result structure is flat and simple
- [ ] Does not use 3rd-party types
- [ ] Uses dynamic JToken only when structure is unknown


---

## Additional Notes
<!-- Any additional information for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Changed HTTP byte request return to a structured result type. This is a breaking change; update any flows or integrations that relied on the previous generic return.
- Documentation
  - Changelog updated to reflect the breaking change and new release.
- Chores
  - Package version bumped to 1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->