### PR TITLE
handle non json jtoken

### DIFF
--- a/Frends.HTTP.Request/CHANGELOG.md
+++ b/Frends.HTTP.Request/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.9.0] - 2026-04-15
+
+### Fixed
+
+- Fixed an issue where selecting JToken as the return format would throw an exception if the server returned a non-JSON response; the response body is now returned as a raw string instead, preserving the status code for flow control.
+
 ## [1.8.0] - 2026-03-07
 
 ### Fixed

--- a/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
@@ -268,7 +268,7 @@ public class UnitTests
     }
 
     [TestMethod]
-    public void RestRequestShouldThrowIfReturnIsNotValidJson()
+    public async Task RestRequest_NonJsonResponse_ShouldReturnRawStringInsteadOfThrowing()
     {
         var input = new Input
         {
@@ -285,12 +285,11 @@ public class UnitTests
             Token = "fooToken"
         };
 
-        // _mockHttpMessageHandler.When(input.Url)
-        //     .Respond("application/json", "<fail>failbar<fail>");
-        var ex = Assert.ThrowsAsync<JsonReaderException>(async () =>
-            await HTTP.Request(input, options, CancellationToken.None));
+        var result = await HTTP.Request(input, options, CancellationToken.None);
 
-        Assert.That(ex.Message.Contains("Unable to read response message as json"));
+        ClassicAssert.IsInstanceOf<string>(result.Body);
+        ClassicAssert.IsTrue(((string)result.Body).Contains("<!--"));
+        ClassicAssert.AreEqual(200, result.StatusCode);
     }
 
     [TestMethod]
@@ -410,5 +409,51 @@ public class UnitTests
         Assert.That(ex, Is.Not.Null);
         Assert.That(ex.Message.Contains(
             $"Certificate with thumbprint: 'INVALIDTHUMBPRINT' not found in {storeLocationText} cert store."));
+    }
+
+    [TestMethod]
+    public async Task RestRequest_NonJsonErrorResponse_ShouldReturnRawStringWithStatusCode()
+    {
+        var input = new Input
+        {
+            Method = Method.Method.GET,
+            Url = $"{BasePath}/html",
+            Headers = new Header[0],
+            Message = "",
+            ResultMethod = ReturnFormat.JToken
+        };
+        var options = new Options
+        {
+            ConnectionTimeoutSeconds = 60,
+            ThrowExceptionOnErrorResponse = false
+        };
+
+        var result = await HTTP.Request(input, options, CancellationToken.None);
+
+        ClassicAssert.AreEqual(200, result.StatusCode);
+        ClassicAssert.IsInstanceOf<string>(result.Body);
+        ClassicAssert.IsTrue(((string)result.Body).Contains("<html"));
+    }
+
+    [TestMethod]
+    public async Task RestRequest_JsonContentType_ShouldStillReturnJToken()
+    {
+        var input = new Input
+        {
+            Method = Method.Method.GET,
+            Url = $"{BasePath}/json",
+            Headers = new Header[0],
+            Message = "",
+            ResultMethod = ReturnFormat.JToken
+        };
+        var options = new Options
+        {
+            ConnectionTimeoutSeconds = 60
+        };
+
+        var result = await HTTP.Request(input, options, CancellationToken.None);
+
+        ClassicAssert.IsInstanceOf<JToken>(result.Body);
+        ClassicAssert.AreEqual(200, result.StatusCode);
     }
 }

--- a/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request.Tests/UnitTests.cs
@@ -412,7 +412,7 @@ public class UnitTests
     }
 
     [TestMethod]
-    public async Task RestRequest_NonJsonErrorResponse_ShouldReturnRawStringWithStatusCode()
+    public async Task RestRequest_HtmlContentType_ShouldReturnRawStringInsteadOfThrowing()
     {
         var input = new Input
         {

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Frends.HTTP.Request.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.8.0</Version>
+		<Version>1.9.0</Version>
 		<Authors>Frends</Authors>
 		<Copyright>Frends</Copyright>
 		<Company>Frends</Company>

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
@@ -102,7 +102,7 @@ public static class HTTP
                         .ReadAsStringAsync(cancellationToken)
                         .ConfigureAwait(false);
 
-                    var rbody = TryParseBodyByContentType(rawBody, responseMessage.Content.Headers?.ContentType);
+                    var rbody = TryParseBody(rawBody);
                     var rstatusCode = (int)responseMessage.StatusCode;
                     var rheaders =
                         GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content.Headers);
@@ -207,34 +207,19 @@ public static class HTTP
         return new StringContent(input.Message ?? string.Empty);
     }
 
-    private static object TryParseBodyByContentType(string responseBody, MediaTypeHeaderValue contentType)
+    private static object TryParseBody(string responseBody)
     {
         if (string.IsNullOrWhiteSpace(responseBody))
             return new JValue("");
 
-        var mediaType = contentType?.MediaType?.ToLowerInvariant();
-
-        // Explicit non-JSON content type — don't even try to parse
-        if (mediaType != null && !IsJsonMediaType(mediaType))
-            return responseBody;
-
-        // Content-Type is JSON (or unknown/missing) — attempt to parse
         try
         {
             return JToken.Parse(responseBody);
         }
         catch (JsonReaderException)
         {
-            // Server lied about content-type, or no content-type was set
-            // Return the raw string rather than throwing — status code is still intact
             return responseBody;
         }
-    }
-
-    private static bool IsJsonMediaType(string mediaType)
-    {
-        // Covers: application/json, application/problem+json, application/ld+json, text/json, etc.
-        return mediaType.Contains("json");
     }
 
     private static HttpClient GetHttpClientForOptions(Options options)

--- a/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
+++ b/Frends.HTTP.Request/Frends.HTTP.Request/Request.cs
@@ -98,9 +98,11 @@ public static class HTTP
 
                     break;
                 case ReturnFormat.JToken:
-                    var rbody = TryParseRequestStringResultAsJToken(await responseMessage.Content
+                    var rawBody = await responseMessage.Content
                         .ReadAsStringAsync(cancellationToken)
-                        .ConfigureAwait(false));
+                        .ConfigureAwait(false);
+
+                    var rbody = TryParseBodyByContentType(rawBody, responseMessage.Content.Headers?.ContentType);
                     var rstatusCode = (int)responseMessage.StatusCode;
                     var rheaders =
                         GetResponseHeaderDictionary(responseMessage.Headers, responseMessage.Content.Headers);
@@ -205,16 +207,34 @@ public static class HTTP
         return new StringContent(input.Message ?? string.Empty);
     }
 
-    private static object TryParseRequestStringResultAsJToken(string response)
+    private static object TryParseBodyByContentType(string responseBody, MediaTypeHeaderValue contentType)
     {
+        if (string.IsNullOrWhiteSpace(responseBody))
+            return new JValue("");
+
+        var mediaType = contentType?.MediaType?.ToLowerInvariant();
+
+        // Explicit non-JSON content type — don't even try to parse
+        if (mediaType != null && !IsJsonMediaType(mediaType))
+            return responseBody;
+
+        // Content-Type is JSON (or unknown/missing) — attempt to parse
         try
         {
-            return string.IsNullOrWhiteSpace(response) ? new JValue("") : JToken.Parse(response);
+            return JToken.Parse(responseBody);
         }
         catch (JsonReaderException)
         {
-            throw new JsonReaderException($"Unable to read response message as json: {response}");
+            // Server lied about content-type, or no content-type was set
+            // Return the raw string rather than throwing — status code is still intact
+            return responseBody;
         }
+    }
+
+    private static bool IsJsonMediaType(string mediaType)
+    {
+        // Covers: application/json, application/problem+json, application/ld+json, text/json, etc.
+        return mediaType.Contains("json");
     }
 
     private static HttpClient GetHttpClientForOptions(Options options)


### PR DESCRIPTION
Please review my changes :)

# *Task Update PR template*

## Review Checklist

- [ ] Task version updated (x.x.0)
- [ ] CHANGELOG.md updated
- [ ] Solution builds
- [ ] Warnings resolved (if possible)
- [ ] Typos resolved
- [ ] Tests cover new code
- [ ] Description how to run tests locally added to README.md (if needed)
- [ ] All tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When JToken return format is selected and the server responds with non-JSON content, the request now returns the response body as a raw string instead of throwing an exception, while preserving the HTTP status code for downstream control flow.

* **Chores**
  * Package version bumped to 1.9.0 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->